### PR TITLE
Add replace_dataset method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    domo_ruby_sdk (0.1.0)
+    domo_ruby_sdk (0.2.0)
       rest-client (~> 2.0)
 
 GEM

--- a/lib/domo_ruby_sdk.rb
+++ b/lib/domo_ruby_sdk.rb
@@ -150,7 +150,7 @@ module DomoRubySdk
       return JSON.parse(response.body)
     end
 
-    # a non-stream write of data to a dataset. useful for only small
+    # a non-stream append of data to a dataset. useful for only small
     # amounts of data.
     def append_dataset(dataset_id, csv_data)
       authenticate unless authenticated?
@@ -160,6 +160,25 @@ module DomoRubySdk
         'Accept': 'application/json'
       }
       endpoint = "#{@@datasets_endpoint}/#{dataset_id}/data?updateMethod=APPEND"
+      response = RestClient::Request.execute(
+        url: endpoint,
+        method: :put,
+        headers: headers,
+        payload: csv_data
+      )
+      return response
+    end
+
+    # a non-stream replace of data to a dataset. useful for only small
+    # amounts of data.
+    def replace_dataset(dataset_id, csv_data)
+      authenticate unless authenticated?
+      headers = {
+        'Content-Type': 'text/csv',
+        'Authorization': "Bearer #{@access_token}",
+        'Accept': 'application/json'
+      }
+      endpoint = "#{@@datasets_endpoint}/#{dataset_id}/data"
       response = RestClient::Request.execute(
         url: endpoint,
         method: :put,

--- a/lib/domo_ruby_sdk/version.rb
+++ b/lib/domo_ruby_sdk/version.rb
@@ -1,3 +1,3 @@
 module DomoRubySdk
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/spec/domo_dataset_spec.rb
+++ b/spec/domo_dataset_spec.rb
@@ -70,6 +70,15 @@ RSpec.describe DomoRubySdk, vcr: true do
       expect(resp['columns']).to eq 3
       expect(resp['rows']).to eq 3
     end
+    it "queries dataset and replaces data" do
+      csv_string = domo.query_dataset($dataset_id)
+      resp = domo.replace_dataset($dataset_id,csv_string)
+      expect(resp.code).to eq 204
+      sleep(5)
+      resp = domo.get_dataset_metadata($dataset_id)
+      expect(resp['columns']).to eq 3
+      expect(resp['rows']).to eq 3
+    end
     it "deletes dataset" do
       resp = domo.delete_dataset($dataset_id)
       expect(resp.code).to eq 204


### PR DESCRIPTION
Added replace_dataset method which uses the Domo API update dataset action in replace mode. Added a spec test to export data from a dataset and then overwrite it with the same data.